### PR TITLE
Do not load unused PerlIO::Layers

### DIFF
--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -4,7 +4,6 @@ use strict;
 use warnings FATAL => 'all';
 use Test::More;
 use Test::Exception;
-use PerlIO::Layers qw/query_handle/;
 
 my $fh;
 lives_ok { open $fh, '<:buffersize(256)', $0; } 'Can open :buffersize(256)';


### PR DESCRIPTION
The test did not use PerlIO::Layers::query_handle(). This patch
removes the unneccessary use of the module. That will also drop it
from a built-time dependencies.